### PR TITLE
Fix hosts setup

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -38,7 +38,7 @@ elasticsearch:
         -
             host: 'localhost'
             port: 9200
-            schema: 'https'
+            scheme: 'https'
             user: 'foo'
             pass: 'bar'
 ```

--- a/src/DI/ElasticsearchExtension.php
+++ b/src/DI/ElasticsearchExtension.php
@@ -28,8 +28,8 @@ class ElasticsearchExtension extends CompilerExtension
 					'user' => Expect::string(),
 					'pass' => Expect::string(),
 				])->castTo('array')
-			)),
-			'retries' => Expect::int(),
+			))->required()->min(1),
+			'retries' => Expect::int(1),
 		]);
 	}
 
@@ -38,14 +38,10 @@ class ElasticsearchExtension extends CompilerExtension
 		$config = $this->config;
 		$builder = $this->getContainerBuilder();
 
-		$builder->addDefinition($this->prefix('clientBuilder'))
-			->setType(ClientBuilder::class)
-			->setFactory([ClientBuilder::class, 'create'])
-			->setArguments($config->hosts);
-
 		$builder->addDefinition($this->prefix('client'))
 			->setType(Client::class)
-			->setFactory(['@' . $this->prefix('clientBuilder'), 'build']);
+			->setFactory([ClientBuilder::class, 'fromConfig'])
+			->setArguments([(array) $config]);
 	}
 
 }

--- a/src/DI/ElasticsearchExtension.php
+++ b/src/DI/ElasticsearchExtension.php
@@ -23,7 +23,7 @@ class ElasticsearchExtension extends CompilerExtension
 				Expect::structure([
 					'host' => Expect::string()->required(),
 					'port' => Expect::int(),
-					'schema' => Expect::string(),
+					'scheme' => Expect::string(),
 					'path' => Expect::string(),
 					'user' => Expect::string(),
 					'pass' => Expect::string(),


### PR DESCRIPTION
Hey. This is fix for 2 issues.

1. There was typo in configuration. It is `scheme` not `schema` [ClientBuilder.php#L659](https://github.com/elastic/elasticsearch-php/blob/master/src/Elasticsearch/ClientBuilder.php#L659)
2. It was not possible to setup hosts. As [ClientBuilder.php#L131](https://github.com/elastic/elasticsearch-php/blob/master/src/Elasticsearch/ClientBuilder.php#L131) does not take any arguments. So when DI call `->build()` on factory, it everytime fallback to default values `localhost:9200`.
New method `getHosts()` is here to not make BC break.
As without it user will be forced to set configuration even for `localhost:9200`.

Tested with on my project.
If it is ok for you, please release new version.
