### PR TITLE
Add support for ElasticSearch 8

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -30,17 +30,3 @@ elasticsearch:
 		- 'localhost'
 ```
 
-### Advanced configuration
-
-```neon
-elasticsearch:
-	hosts:
-		-
-			host: 'localhost'
-			port: 9200
-			scheme: 'https'
-			user: 'foo'
-			pass: 'bar'
-```
-
-**NOTE:** The `host` is required, others are recommended, but not necessary.

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     }
   ],
   "require": {
-    "php": ">=7.2",
-    "elasticsearch/elasticsearch": "^6.8.0|^7.0.0",
+    "php": ">=7.4",
+    "elasticsearch/elasticsearch": "^8.0.0",
     "nette/di": "^3.0.1"
   },
   "require-dev": {
@@ -45,7 +45,8 @@
   "config": {
     "sort-packages": true,
     "allow-plugins": {
-      "dealerdirect/phpcodesniffer-composer-installer": true
+      "dealerdirect/phpcodesniffer-composer-installer": true,
+      "php-http/discovery": true
     }
   },
   "extra": {

--- a/src/DI/ElasticsearchExtension.php
+++ b/src/DI/ElasticsearchExtension.php
@@ -21,8 +21,8 @@ class ElasticsearchExtension extends CompilerExtension
 			'hosts'           => Expect::arrayOf(Expect::string())->required()->min(1),
 			'retries'         => Expect::int(1),
 			'sslVerification' => Expect::bool(),
-			'apiKey'          => Expect::arrayOf(Expect::string())->min(1)->max(2)->nullable(),
-			'basicAuthentication' => Expect::arrayOf(Expect::string())->min(2)->max(2)->nullable(),
+			'apiKey'          => Expect::anyOf(Expect::arrayOf(Expect::string())->min(1)->max(2), null),
+			'basicAuthentication' => Expect::anyOf(Expect::arrayOf(Expect::string())->min(2)->max(2), null),
 		]);
 	}
 

--- a/src/DI/ElasticsearchExtension.php
+++ b/src/DI/ElasticsearchExtension.php
@@ -2,10 +2,9 @@
 
 namespace Contributte\Elasticsearch\DI;
 
-use Elasticsearch\Client;
-use Elasticsearch\ClientBuilder;
+use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\ClientBuilder;
 use Nette\DI\CompilerExtension;
-use Nette\DI\Definitions\Statement;
 use Nette\Schema\Expect;
 use Nette\Schema\Schema;
 use stdClass;
@@ -19,31 +18,26 @@ class ElasticsearchExtension extends CompilerExtension
 	public function getConfigSchema(): Schema
 	{
 		return Expect::structure([
-			'hosts' => Expect::arrayOf(Expect::anyOf(
-				Expect::string(),
-				Expect::type(Statement::class),
-				Expect::structure([
-					'host' => Expect::anyOf(Expect::string(), Expect::type(Statement::class))->required(),
-					'port' => Expect::anyOf(Expect::int(), Expect::type(Statement::class)),
-					'scheme' => Expect::anyOf(Expect::string(), Expect::type(Statement::class)),
-					'path' => Expect::anyOf(Expect::string(), Expect::type(Statement::class)),
-					'user' => Expect::anyOf(Expect::string(), Expect::type(Statement::class)),
-					'pass' => Expect::anyOf(Expect::string(), Expect::type(Statement::class)),
-				])->castTo('array')
-			))->required()->min(1),
-			'retries' => Expect::int(1),
+			'hosts'           => Expect::arrayOf(Expect::string())->required()->min(1),
+			'retries'         => Expect::int(1),
+			'sslVerification' => Expect::bool(),
+			'apiKey'          => Expect::arrayOf(Expect::string())->min(1)->max(2),
 		]);
 	}
 
 	public function beforeCompile(): void
 	{
-		$config = $this->config;
+		$config  = $this->config;
 		$builder = $this->getContainerBuilder();
 
 		$builder->addDefinition($this->prefix('client'))
 			->setType(Client::class)
 			->setFactory([ClientBuilder::class, 'fromConfig'])
-			->setArguments([(array) $config]);
+			->setArguments(
+				[
+					array_filter((array) $config),
+				]
+			);
 	}
 
 }

--- a/src/DI/ElasticsearchExtension.php
+++ b/src/DI/ElasticsearchExtension.php
@@ -21,7 +21,8 @@ class ElasticsearchExtension extends CompilerExtension
 			'hosts'           => Expect::arrayOf(Expect::string())->required()->min(1),
 			'retries'         => Expect::int(1),
 			'sslVerification' => Expect::bool(),
-			'apiKey'          => Expect::arrayOf(Expect::string())->min(1)->max(2),
+			'apiKey'          => Expect::arrayOf(Expect::string())->min(1)->max(2)->nullable(),
+			'basicAuthentication' => Expect::arrayOf(Expect::string())->min(2)->max(2)->nullable(),
 		]);
 	}
 

--- a/src/DI/ElasticsearchExtension.php
+++ b/src/DI/ElasticsearchExtension.php
@@ -20,7 +20,7 @@ class ElasticsearchExtension extends CompilerExtension
 		return Expect::structure([
 			'hosts'           => Expect::arrayOf(Expect::string())->required()->min(1),
 			'retries'         => Expect::int(1),
-			'sslVerification' => Expect::bool(),
+			'sslVerification' => Expect::bool(true),
 			'apiKey'          => Expect::anyOf(Expect::arrayOf(Expect::string())->min(1)->max(2), null),
 			'basicAuthentication' => Expect::anyOf(Expect::arrayOf(Expect::string())->min(2)->max(2), null),
 		]);

--- a/tests/cases/DI/ConfigurationTest.phpt
+++ b/tests/cases/DI/ConfigurationTest.phpt
@@ -73,3 +73,23 @@ test(function (): void {
 	Assert::type(Container::class, $container);
 	Assert::type(Client::class, $container->getService('elasticsearch.client'));
 });
+
+
+test(function (): void {
+	$loader = new ContainerLoader(TEMP_DIR, true);
+	$class = $loader->load(function (Compiler $compiler): void {
+		$compiler->addExtension('elasticsearch', new ElasticsearchExtension());
+		$compiler->loadConfig(FileMock::create('
+			elasticsearch:
+					hosts:
+					    - localhost
+					apiKey: null
+		', 'neon'));
+	}, '1d');
+
+	/** @var Container $container */
+	$container = new $class();
+
+	Assert::type(Container::class, $container);
+	Assert::type(Client::class, $container->getService('elasticsearch.client'));
+});

--- a/tests/cases/DI/ConfigurationTest.phpt
+++ b/tests/cases/DI/ConfigurationTest.phpt
@@ -1,10 +1,11 @@
 <?php declare(strict_types = 1);
 
 use Contributte\Elasticsearch\DI\ElasticsearchExtension;
-use Elasticsearch\Client;
+use Elastic\Elasticsearch\Client;
 use Nette\DI\Compiler;
 use Nette\DI\Container;
 use Nette\DI\ContainerLoader;
+use Nette\DI\InvalidConfigurationException;
 use Tester\Assert;
 use Tester\FileMock;
 
@@ -30,17 +31,41 @@ test(function (): void {
 
 test(function (): void {
 	$loader = new ContainerLoader(TEMP_DIR, true);
-	$class = $loader->load(function (Compiler $compiler): void {
-		$compiler->addExtension('elasticsearch', new ElasticsearchExtension());
-		$compiler->loadConfig(FileMock::create('
+	// Elasticsearch removed Extended Host Configuration support in 8.0
+	Assert::exception(function () use ($loader) {
+		return $loader->load(function (Compiler $compiler): void {
+			$compiler->addExtension('elasticsearch', new ElasticsearchExtension());
+			$compiler->loadConfig(
+				FileMock::create(
+					'
 			elasticsearch:
 					hosts:
 					    - localhost
 					    -
 					    	host: 192.168.1.100
 					    	port: 9999
+		',
+					'neon'
+				)
+			);
+		}, '1b');
+	}, InvalidConfigurationException::class);
+});
+
+
+test(function (): void {
+	$loader = new ContainerLoader(TEMP_DIR, true);
+	$class = $loader->load(function (Compiler $compiler): void {
+		$compiler->addExtension('elasticsearch', new ElasticsearchExtension());
+		$compiler->loadConfig(FileMock::create('
+			elasticsearch:
+					hosts:
+					    - localhost
+					sslVerification: false
+					apiKey:
+						- testapikey
 		', 'neon'));
-	}, '1b');
+	}, '1c');
 
 	/** @var Container $container */
 	$container = new $class();


### PR DESCRIPTION
I have modified the code to work with version 8 of the Elasticsearch PHP library. Unfortunately it breaks compatibility with older Elasticsearch library versions as the namespace changed. Another breaking change is that in the new version Elasticsearch dropped support for the "Extended Host Configuration" syntax and the minimum required PHP version changed to 7.4. 

Also added some more options to the config schema, there are also other options that should probably be supported, might add them in another commit or create another PR.