### PR TITLE
Implement Tracy debugging panel

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -6,6 +6,7 @@ Find out more about [elasticsearch-php](https://github.com/elastic/elasticsearch
 
 - [Setup](#setup)
 - [Configuration](#configuration)
+- [Tracy Panel](#tracy-panel)
 
 ## Setup
 
@@ -32,3 +33,27 @@ elasticsearch:
 ```
 
 **NOTE:** The `host` is required, others are recommended, but not necessary.
+
+## Tracy Panel
+
+Enable the Tracy debugger panel to monitor Elasticsearch queries during development.
+
+```neon
+elasticsearch:
+	hosts: [localhost]
+	debug: true
+```
+
+The Tracy panel displays:
+- Number of queries and total execution time
+- HTTP method and endpoint for each request
+- Request body and response data (expandable)
+- Response status codes
+- Backtrace showing where each query originated
+- Configuration details (with sensitive data masked)
+
+**NOTE:** The `debug` option requires the `tracy/tracy` package. Install it via:
+
+```bash
+composer require tracy/tracy
+```

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,11 @@
   "require-dev": {
     "contributte/qa": "^0.4",
     "contributte/tester": "^0.4",
-    "contributte/phpstan": "^0.1"
+    "contributte/phpstan": "^0.1",
+    "tracy/tracy": "^2.10"
+  },
+  "suggest": {
+    "tracy/tracy": "For Tracy debugger panel integration (debug mode)"
   },
   "conflict": {
     "psr/http-message": "<2.0"

--- a/src/DI/ElasticsearchExtension.php
+++ b/src/DI/ElasticsearchExtension.php
@@ -2,12 +2,18 @@
 
 namespace Contributte\Elasticsearch\DI;
 
+use Contributte\Elasticsearch\Tracy\ClientFactory;
+use Contributte\Elasticsearch\Tracy\ElasticsearchPanel;
+use Contributte\Elasticsearch\Tracy\QueryLogger;
 use Elastic\Elasticsearch\Client;
 use Elastic\Elasticsearch\ClientBuilder;
 use Nette\DI\CompilerExtension;
+use Nette\DI\Definitions\ServiceDefinition;
+use Nette\DI\Definitions\Statement;
 use Nette\Schema\Expect;
 use Nette\Schema\Schema;
 use stdClass;
+use Tracy\Bar;
 
 /**
  * @method stdClass getConfig()
@@ -23,19 +29,55 @@ class ElasticsearchExtension extends CompilerExtension
 			'sslVerification' => Expect::bool(true),
 			'apiKey' => Expect::anyOf(Expect::arrayOf(Expect::string())->min(1)->max(2), null),
 			'basicAuthentication' => Expect::anyOf(Expect::arrayOf(Expect::string())->min(2)->max(2), null),
+			'debug' => Expect::bool(false),
 		]);
 	}
 
 	public function beforeCompile(): void
 	{
 		$config = $this->getConfig();
-		$config = array_filter((array) $config, fn ($value) => $value !== null);
 		$builder = $this->getContainerBuilder();
 
-		$builder->addDefinition($this->prefix('client'))
-			->setType(Client::class)
-			->setFactory([ClientBuilder::class, 'fromConfig'])
-			->setArguments([$config]);
+		$debug = $config->debug && class_exists(Bar::class);
+
+		// Filter out null values and remove debug from config passed to client
+		$clientConfig = array_filter((array) $config, fn ($value) => $value !== null);
+		unset($clientConfig['debug']);
+
+		if ($debug) {
+			// Register QueryLogger
+			$builder->addDefinition($this->prefix('queryLogger'))
+				->setType(QueryLogger::class);
+
+			// Register ElasticsearchPanel
+			$panel = $builder->addDefinition($this->prefix('panel'))
+				->setType(ElasticsearchPanel::class)
+				->setArguments([new Statement('@' . $this->prefix('queryLogger'))]);
+
+			$panel->addSetup('setConfig', [$clientConfig]);
+
+			// Register panel with Tracy Bar
+			if ($builder->hasDefinition('tracy.bar')) {
+				$tracyBar = $builder->getDefinition('tracy.bar');
+				assert($tracyBar instanceof ServiceDefinition);
+				$tracyBar->addSetup('addPanel', [new Statement('@' . $this->prefix('panel'))]);
+			}
+
+			// Create client with logging using ClientFactory
+			$builder->addDefinition($this->prefix('client'))
+				->setType(Client::class)
+				->setFactory([ClientFactory::class, 'create'], [
+					$clientConfig,
+					new Statement('Http\Discovery\Psr18ClientDiscovery::find'),
+					new Statement('@' . $this->prefix('queryLogger')),
+				]);
+		} else {
+			// Create client without logging
+			$builder->addDefinition($this->prefix('client'))
+				->setType(Client::class)
+				->setFactory([ClientBuilder::class, 'fromConfig'])
+				->setArguments([$clientConfig]);
+		}
 	}
 
 }

--- a/src/Tracy/ClientFactory.php
+++ b/src/Tracy/ClientFactory.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Elasticsearch\Tracy;
+
+use Elastic\Elasticsearch\Client;
+use Elastic\Elasticsearch\ClientBuilder;
+use Psr\Http\Client\ClientInterface;
+
+/**
+ * Factory for creating Elasticsearch client with optional query logging.
+ */
+class ClientFactory
+{
+
+	/**
+	 * @param array{hosts?: array<string>, retries?: int, sslVerification?: bool, apiKey?: array<string>, basicAuthentication?: array<string>} $config
+	 */
+	public static function create(
+		array $config,
+		?ClientInterface $httpClient = null,
+		?QueryLogger $logger = null,
+	): Client
+	{
+		$builder = ClientBuilder::create();
+
+		// Set hosts
+		if (isset($config['hosts'])) {
+			$builder->setHosts($config['hosts']);
+		}
+
+		// Set retries
+		if (isset($config['retries'])) {
+			$builder->setRetries($config['retries']);
+		}
+
+		// Set SSL verification
+		if (isset($config['sslVerification'])) {
+			$builder->setSSLVerification($config['sslVerification']);
+		}
+
+		// Set API key
+		if (isset($config['apiKey'])) {
+			$builder->setApiKey(...$config['apiKey']);
+		}
+
+		// Set basic authentication
+		if (isset($config['basicAuthentication'])) {
+			$builder->setBasicAuthentication(...$config['basicAuthentication']);
+		}
+
+		// Set custom HTTP client with logging wrapper if provided
+		if ($httpClient !== null && $logger !== null) {
+			$loggingClient = new LoggingHttpClient($httpClient, $logger);
+			$builder->setHttpClient($loggingClient);
+		} elseif ($httpClient !== null) {
+			$builder->setHttpClient($httpClient);
+		}
+
+		return $builder->build();
+	}
+
+}

--- a/src/Tracy/ElasticsearchPanel.php
+++ b/src/Tracy/ElasticsearchPanel.php
@@ -1,0 +1,89 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Elasticsearch\Tracy;
+
+use Tracy\IBarPanel;
+
+/**
+ * Tracy debugger bar panel for Elasticsearch queries.
+ */
+class ElasticsearchPanel implements IBarPanel
+{
+
+	/** @var array<string, mixed> */
+	private array $config = [];
+
+	public function __construct(
+		private QueryLogger $logger,
+	)
+	{
+	}
+
+	/**
+	 * @param array<string, mixed> $config
+	 */
+	public function setConfig(array $config): void
+	{
+		$this->config = $config;
+	}
+
+	/**
+	 * Renders HTML code for custom tab.
+	 */
+	public function getTab(): string
+	{
+		// Variables used in template
+		// phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$queriesNum = $this->logger->getQueryCount();
+		// phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$totalTime = $this->logger->getTotalTime();
+
+		ob_start();
+		require __DIR__ . '/templates/tab.phtml';
+
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Renders HTML code for custom panel.
+	 */
+	public function getPanel(): string
+	{
+		// Variables used in template
+		// phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$queriesNum = $this->logger->getQueryCount();
+		// phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$totalTime = $this->logger->getTotalTime();
+		// phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$queries = $this->logger->getQueries();
+		// phpcs:ignore SlevomatCodingStandard.Variables.UnusedVariable.UnusedVariable
+		$config = $this->maskSensitiveConfig($this->config);
+
+		ob_start();
+		require __DIR__ . '/templates/panel.phtml';
+
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Mask sensitive configuration values.
+	 *
+	 * @param array<string, mixed> $config
+	 * @return array<string, mixed>
+	 */
+	private function maskSensitiveConfig(array $config): array
+	{
+		$sensitiveKeys = ['apiKey', 'basicAuthentication'];
+
+		foreach ($sensitiveKeys as $key) {
+			if (isset($config[$key])) {
+				$config[$key] = is_array($config[$key])
+					? array_map(fn () => '***', $config[$key])
+					: '***';
+			}
+		}
+
+		return $config;
+	}
+
+}

--- a/src/Tracy/LoggingHttpClient.php
+++ b/src/Tracy/LoggingHttpClient.php
@@ -1,0 +1,124 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Elasticsearch\Tracy;
+
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * PSR-18 HTTP client wrapper that logs requests and responses for Tracy debugging.
+ */
+class LoggingHttpClient implements ClientInterface
+{
+
+	public function __construct(
+		private ClientInterface $innerClient,
+		private QueryLogger $logger,
+	)
+	{
+	}
+
+	public function sendRequest(RequestInterface $request): ResponseInterface
+	{
+		$startTime = microtime(true);
+
+		// Extract request information
+		$method = $request->getMethod();
+		$uri = $request->getUri();
+		$endpoint = $uri->getPath();
+
+		$params = [];
+		parse_str($uri->getQuery(), $params);
+		/** @var array<string, mixed> $params */
+		$params = $params;
+
+		// Get request body
+		$body = (string) $request->getBody();
+		$request->getBody()->rewind();
+
+		$bodyDecoded = $body !== '' ? json_decode($body, true) : null;
+
+		// Capture backtrace (filter out internal calls)
+		$backtrace = $this->captureBacktrace();
+
+		try {
+			$response = $this->innerClient->sendRequest($request);
+			$duration = microtime(true) - $startTime;
+
+			// Get response body
+			$responseBody = (string) $response->getBody();
+			$response->getBody()->rewind();
+
+			$responseDecoded = $responseBody !== '' ? json_decode($responseBody, true) : null;
+
+			$this->logger->logQuery(
+				$method,
+				$endpoint,
+				$params,
+				$bodyDecoded,
+				$responseDecoded,
+				$response->getStatusCode(),
+				$duration,
+				$backtrace,
+			);
+
+			return $response;
+		} catch (\Throwable $e) {
+			$duration = microtime(true) - $startTime;
+
+			$this->logger->logQuery(
+				$method,
+				$endpoint,
+				$params,
+				$bodyDecoded,
+				['error' => $e->getMessage()],
+				0,
+				$duration,
+				$backtrace,
+			);
+
+			throw $e;
+		}
+	}
+
+	/**
+	 * Capture backtrace filtering out internal Elasticsearch client calls.
+	 *
+	 * @return array<int, array{file?: string, line?: int, class?: string, function?: string}>
+	 */
+	private function captureBacktrace(): array
+	{
+		$backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+		$filtered = [];
+
+		foreach ($backtrace as $trace) {
+			// Skip internal Elasticsearch and HTTP client traces
+			$class = $trace['class'] ?? '';
+			if (
+				str_starts_with($class, 'Elastic\\Elasticsearch\\')
+				|| str_starts_with($class, 'Contributte\\Elasticsearch\\Tracy\\')
+				|| str_starts_with($class, 'GuzzleHttp\\')
+				|| str_starts_with($class, 'Http\\')
+			) {
+				continue;
+			}
+
+			// Include trace if it has a file
+			if (isset($trace['file'])) {
+				$filtered[] = [
+					'file' => $trace['file'],
+					'line' => $trace['line'] ?? 0,
+					'class' => $trace['class'] ?? null,
+					'function' => $trace['function'],
+				];
+			}
+		}
+
+		/** @var array<int, array{file?: string, line?: int, class?: string, function?: string}> $result */
+		$result = array_slice($filtered, 0, 10); // Limit to 10 entries
+
+		return $result;
+	}
+
+}

--- a/src/Tracy/QueryLogger.php
+++ b/src/Tracy/QueryLogger.php
@@ -1,0 +1,69 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Elasticsearch\Tracy;
+
+/**
+ * Stores Elasticsearch query information for Tracy panel debugging.
+ */
+class QueryLogger
+{
+
+	/** @var array<int, array{method: string, endpoint: string, params: array<string, mixed>, body: mixed, response: mixed, statusCode: int, duration: float, backtrace: array<int, array{file?: string, line?: int, class?: string, function?: string}>}> */
+	private array $queries = [];
+
+	private float $totalTime = 0.0;
+
+	/**
+	 * @param array<string, mixed> $params
+	 * @param array<int, array{file?: string, line?: int, class?: string, function?: string}> $backtrace
+	 */
+	public function logQuery(
+		string $method,
+		string $endpoint,
+		array $params,
+		mixed $body,
+		mixed $response,
+		int $statusCode,
+		float $duration,
+		array $backtrace = [],
+	): void
+	{
+		$this->queries[] = [
+			'method' => $method,
+			'endpoint' => $endpoint,
+			'params' => $params,
+			'body' => $body,
+			'response' => $response,
+			'statusCode' => $statusCode,
+			'duration' => $duration,
+			'backtrace' => $backtrace,
+		];
+
+		$this->totalTime += $duration;
+	}
+
+	/**
+	 * @return array<int, array{method: string, endpoint: string, params: array<string, mixed>, body: mixed, response: mixed, statusCode: int, duration: float, backtrace: array<int, array{file?: string, line?: int, class?: string, function?: string}>}>
+	 */
+	public function getQueries(): array
+	{
+		return $this->queries;
+	}
+
+	public function getQueryCount(): int
+	{
+		return count($this->queries);
+	}
+
+	public function getTotalTime(): float
+	{
+		return $this->totalTime;
+	}
+
+	public function clear(): void
+	{
+		$this->queries = [];
+		$this->totalTime = 0.0;
+	}
+
+}

--- a/src/Tracy/templates/panel.phtml
+++ b/src/Tracy/templates/panel.phtml
@@ -1,0 +1,136 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Elasticsearch\Tracy;
+
+use Tracy\Dumper;
+use Tracy\Helpers;
+
+/** @var int $queriesNum */
+/** @var float $totalTime */
+/** @var array<string, mixed> $config */
+/** @var array<int, array{method: string, endpoint: string, params: array<string, mixed>, body: mixed, response: mixed, statusCode: int, duration: float, backtrace: array<int, array{file?: string, line?: int, class?: string, function?: string}>}> $queries */
+?>
+
+<style>
+	#tracy-debug .elasticsearch-panel { max-width: 900px; }
+	#tracy-debug .elasticsearch-panel h2 { font-size: 23px; color: #FEC514; }
+	#tracy-debug .elasticsearch-panel table { width: 100%; border-collapse: collapse; }
+	#tracy-debug .elasticsearch-panel th,
+	#tracy-debug .elasticsearch-panel td { text-align: left; padding: 4px 8px; }
+	#tracy-debug .elasticsearch-panel th { background: #343741; color: #FEC514; }
+	#tracy-debug .elasticsearch-panel tr:nth-child(even) { background: #f5f5f5; }
+	#tracy-debug .elasticsearch-panel .status-ok { color: #00BFB3; font-weight: bold; }
+	#tracy-debug .elasticsearch-panel .status-error { color: #F04E98; font-weight: bold; }
+	#tracy-debug .elasticsearch-panel .method { font-weight: bold; color: #343741; }
+	#tracy-debug .elasticsearch-panel .method-get { color: #00BFB3; }
+	#tracy-debug .elasticsearch-panel .method-post { color: #FEC514; }
+	#tracy-debug .elasticsearch-panel .method-put { color: #1BA9F5; }
+	#tracy-debug .elasticsearch-panel .method-delete { color: #F04E98; }
+	#tracy-debug .elasticsearch-panel .endpoint { font-family: monospace; word-break: break-all; }
+	#tracy-debug .elasticsearch-panel .duration { text-align: right; white-space: nowrap; }
+	#tracy-debug .elasticsearch-panel pre { margin: 0; white-space: pre-wrap; word-break: break-all; background: #f8f8f8; padding: 4px; border-radius: 3px; max-height: 200px; overflow: auto; }
+	#tracy-debug .elasticsearch-panel .tracy-toggle { cursor: pointer; color: #125EAE; }
+	#tracy-debug .elasticsearch-panel .tracy-toggle:hover { color: #343741; }
+	#tracy-debug .elasticsearch-panel .backtrace { font-size: 11px; color: #666; margin-top: 4px; }
+	#tracy-debug .elasticsearch-panel .config-table td:first-child { font-weight: bold; width: 150px; }
+</style>
+
+<div class="elasticsearch-panel">
+	<h2>
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 24px; width: auto; display: inline; vertical-align: middle;">
+			<path fill="#343741" d="M38.1 36.2H9.6c.5 6.5 2.9 12.5 6.7 17.3h16.6c5.9 0 10.7-4.8 10.7-10.7V42c0-3.2-2.6-5.8-5.5-5.8z"/>
+			<path fill="#00BFB3" d="M9.6 27.8h28.5c3.1 0 5.6-2.6 5.6-5.6v-.9c0-5.9-4.8-10.7-10.7-10.7H16.3C12.5 15.3 10.1 21.3 9.6 27.8z"/>
+			<path fill="#FEC514" d="M0 32c0 3 .4 5.9 1.2 8.7h6.3c2.8 0 5-2.2 5-5v-7.4c0-2.8-2.2-5-5-5H1.2C.4 26.1 0 29 0 32z"/>
+			<path fill="#F04E98" d="M64 32c0-15.5-11-28.4-25.6-31.4C53.3 6.7 64 17.9 64 32s-10.7 25.3-25.6 31.4C53 60.4 64 47.5 64 32z"/>
+		</svg>
+		Elasticsearch
+	</h2>
+
+	<?php if ($queriesNum === 0): ?>
+		<p><em>No queries executed.</em></p>
+	<?php else: ?>
+		<p>
+			<strong><?= $queriesNum ?></strong> <?= $queriesNum === 1 ? 'query' : 'queries' ?>
+			executed in <strong><?= number_format($totalTime * 1000, 2) ?> ms</strong>
+		</p>
+	<?php endif; ?>
+
+	<?php if (!empty($config)): ?>
+		<h3 class="tracy-toggle tracy-collapsed" data-tracy-ref="^div .elasticsearch-config">Configuration</h3>
+		<div class="tracy-collapsed elasticsearch-config">
+			<table class="config-table">
+				<?php foreach ($config as $key => $value): ?>
+					<tr>
+						<td><?= Helpers::escapeHtml($key) ?></td>
+						<td><?= is_array($value) ? Helpers::escapeHtml(implode(', ', $value)) : Helpers::escapeHtml((string) $value) ?></td>
+					</tr>
+				<?php endforeach; ?>
+			</table>
+		</div>
+	<?php endif; ?>
+
+	<?php if ($queriesNum > 0): ?>
+		<table>
+			<thead>
+				<tr>
+					<th style="width: 60px;">Method</th>
+					<th>Endpoint</th>
+					<th style="width: 60px;">Status</th>
+					<th style="width: 80px;" class="duration">Duration</th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ($queries as $i => $query): ?>
+					<tr>
+						<td>
+							<span class="method method-<?= strtolower($query['method']) ?>"><?= Helpers::escapeHtml($query['method']) ?></span>
+						</td>
+						<td>
+							<span class="endpoint"><?= Helpers::escapeHtml($query['endpoint']) ?></span>
+							<?php if (!empty($query['params'])): ?>
+								<br><small>?<?= Helpers::escapeHtml(http_build_query($query['params'])) ?></small>
+							<?php endif; ?>
+
+							<?php if ($query['body'] !== null): ?>
+								<div class="tracy-toggle tracy-collapsed" data-tracy-ref="^tr .query-body-<?= $i ?>">Request Body</div>
+								<div class="tracy-collapsed query-body-<?= $i ?>">
+									<pre><?= Helpers::escapeHtml(json_encode($query['body'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '') ?></pre>
+								</div>
+							<?php endif; ?>
+
+							<?php if ($query['response'] !== null): ?>
+								<div class="tracy-toggle tracy-collapsed" data-tracy-ref="^tr .query-response-<?= $i ?>">Response</div>
+								<div class="tracy-collapsed query-response-<?= $i ?>">
+									<pre><?= Helpers::escapeHtml(json_encode($query['response'], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '') ?></pre>
+								</div>
+							<?php endif; ?>
+
+							<?php if (!empty($query['backtrace'])): ?>
+								<div class="tracy-toggle tracy-collapsed" data-tracy-ref="^tr .query-trace-<?= $i ?>">Backtrace</div>
+								<div class="tracy-collapsed query-trace-<?= $i ?> backtrace">
+									<?php foreach ($query['backtrace'] as $trace): ?>
+										<?php if (isset($trace['file'])): ?>
+											<?= Helpers::escapeHtml($trace['file']) ?>:<?= $trace['line'] ?? 0 ?>
+											<?php if (isset($trace['class']) || isset($trace['function'])): ?>
+												<br>&nbsp;&nbsp;&nbsp;&nbsp;<?= isset($trace['class']) ? Helpers::escapeHtml($trace['class']) . '::' : '' ?><?= Helpers::escapeHtml($trace['function'] ?? '') ?>()
+											<?php endif; ?>
+											<br>
+										<?php endif; ?>
+									<?php endforeach; ?>
+								</div>
+							<?php endif; ?>
+						</td>
+						<td>
+							<span class="<?= $query['statusCode'] >= 200 && $query['statusCode'] < 300 ? 'status-ok' : 'status-error' ?>">
+								<?= $query['statusCode'] ?>
+							</span>
+						</td>
+						<td class="duration">
+							<?= number_format($query['duration'] * 1000, 2) ?> ms
+						</td>
+					</tr>
+				<?php endforeach; ?>
+			</tbody>
+		</table>
+	<?php endif; ?>
+</div>

--- a/src/Tracy/templates/tab.phtml
+++ b/src/Tracy/templates/tab.phtml
@@ -1,0 +1,29 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Elasticsearch\Tracy;
+
+/** @var int $queriesNum */
+/** @var float $totalTime */
+?>
+<span title="Elasticsearch">
+	<span class="tracy-label">
+	<?php if ($queriesNum <= 0): ?>
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 16px; width: auto; display: inline; opacity: 0.5;">
+			<path fill="#343741" d="M38.1 36.2H9.6c.5 6.5 2.9 12.5 6.7 17.3h16.6c5.9 0 10.7-4.8 10.7-10.7V42c0-3.2-2.6-5.8-5.5-5.8z"/>
+			<path fill="#00BFB3" d="M9.6 27.8h28.5c3.1 0 5.6-2.6 5.6-5.6v-.9c0-5.9-4.8-10.7-10.7-10.7H16.3C12.5 15.3 10.1 21.3 9.6 27.8z"/>
+			<path fill="#FEC514" d="M0 32c0 3 .4 5.9 1.2 8.7h6.3c2.8 0 5-2.2 5-5v-7.4c0-2.8-2.2-5-5-5H1.2C.4 26.1 0 29 0 32z"/>
+			<path fill="#F04E98" d="M64 32c0-15.5-11-28.4-25.6-31.4C53.3 6.7 64 17.9 64 32s-10.7 25.3-25.6 31.4C53 60.4 64 47.5 64 32z"/>
+		</svg>
+	<?php else: ?>
+		<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" style="height: 16px; width: auto; display: inline;">
+			<path fill="#343741" d="M38.1 36.2H9.6c.5 6.5 2.9 12.5 6.7 17.3h16.6c5.9 0 10.7-4.8 10.7-10.7V42c0-3.2-2.6-5.8-5.5-5.8z"/>
+			<path fill="#00BFB3" d="M9.6 27.8h28.5c3.1 0 5.6-2.6 5.6-5.6v-.9c0-5.9-4.8-10.7-10.7-10.7H16.3C12.5 15.3 10.1 21.3 9.6 27.8z"/>
+			<path fill="#FEC514" d="M0 32c0 3 .4 5.9 1.2 8.7h6.3c2.8 0 5-2.2 5-5v-7.4c0-2.8-2.2-5-5-5H1.2C.4 26.1 0 29 0 32z"/>
+			<path fill="#F04E98" d="M64 32c0-15.5-11-28.4-25.6-31.4C53.3 6.7 64 17.9 64 32s-10.7 25.3-25.6 31.4C53 60.4 64 47.5 64 32z"/>
+		</svg>
+	<?php endif; ?>
+	&nbsp;
+	<?= ($queriesNum > 0 ? $queriesNum . ' queries' : '') ?>
+	<?= ($totalTime > 0 ? ' / ' . number_format($totalTime * 1000, 1, '.', ' ') . ' ms' : '') ?>
+	</span>
+</span>


### PR DESCRIPTION
Add Tracy panel integration to visualize Elasticsearch requests during development:

- QueryLogger: stores query information (method, endpoint, body, response, duration)
- LoggingHttpClient: PSR-18 client wrapper that intercepts and logs HTTP requests
- ElasticsearchPanel: Tracy bar panel showing query count, time, and details
- ClientFactory: creates Elasticsearch client with optional logging

Features:
- Display number of queries and total execution time in Tracy bar
- Show HTTP method, endpoint, status code, and duration for each query
- Expandable request body and response data
- Backtrace showing where each query originated
- Configuration display with sensitive data masked

Enable with `debug: true` in config. Requires tracy/tracy package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Tracy debugger integration for Elasticsearch debugging in development mode
  * Query debugging panel displays query count, execution time, detailed metrics, and request/response information

* **Documentation**
  * Added Tracy panel configuration guide to README

* **Chores**
  * Added Tracy debugger as a development dependency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->